### PR TITLE
Add dark mode support with next-themes

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,8 +2,19 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 
 export default function Header() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const toggleTheme = () => setTheme(theme === "dark" ? "light" : "dark");
+
   return (
     <header className="w-full py-4 px-6 flex justify-between items-center border-b border-gray-200 dark:border-gray-800">
       <Link href="/" className="flex items-center gap-2">
@@ -11,10 +22,21 @@ export default function Header() {
         <span className="text-xl font-bold gradient-text ml-2">Open Idea</span>
 
       </Link>
-      <nav className="space-x-6 text-sm font-medium">
+      <nav className="space-x-6 text-sm font-medium flex items-center gap-4">
         <Link href="/about" className="hover:text-green-600">About</Link>
         <Link href="/projects" className="hover:text-green-600">Projects</Link>
         <Link href="/contribute" className="hover:text-green-600">Contribute</Link>
+        <button
+          onClick={toggleTheme}
+          aria-label="Toggle Theme"
+          className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+        >
+          {mounted && theme === "dark" ? (
+            <i className="fas fa-sun" />
+          ) : (
+            <i className="fas fa-moon" />
+          )}
+        </button>
       </nav>
     </header>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,6 +40,22 @@
   }
 }
 
+.dark {
+  --background: #0d0f11;
+  --foreground: #ededed;
+  --dark-bg: #0d0f11;
+  --dark-secondary: #15171a;
+  --dark-card: #1b1d21;
+  --neon-green: #39ff14;
+  --neon-blue: #38bdf8;
+  --neon-purple: #a78bfa;
+  --neon-cyan: #0ff0fc;
+  --shadow-neon-green: 0 0 16px #39ff14a0;
+  --shadow-neon-blue: 0 0 16px #38bdf880;
+  --shadow-neon-cyan: 0 0 16px #0ff0fc90;
+  --shadow-neon-purple: 0 0 16px #a78bfa70;
+}
+
 /* --- Base Typography and Background --- */
 body {
   background: var(--background);
@@ -166,6 +182,13 @@ a {
     background: var(--dark-bg) !important;
     color: var(--foreground) !important;
   }
+}
+
+.dark section,
+.dark .bg-white,
+.dark .bg-gray-50 {
+  background: var(--dark-bg) !important;
+  color: var(--foreground) !important;
 }
 
 /* --- Utility for Card Borders of All Neon Colors (for reuse) --- */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "next-themes";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,11 +24,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- wrap app with `ThemeProvider`
- create a theme toggle in the header
- support Tailwind `dark` mode via config
- add `.dark` CSS variables

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities in Hero.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_686f6388f7088332951e506bb0755615