### PR TITLE
Fix dynamic year in footer

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 export default function Footer() {
+  const currentYear = new Date().getFullYear();
   return (
     <>
       {/* 🌟 Glowing Emerald Divider */}
@@ -84,7 +85,7 @@ export default function Footer() {
 
         {/* 🔚 Bottom Note */}
         <div className="mt-8 text-center text-xs text-gray-500">
-          © 2025 ECOSYZ. All rights reserved. Built with{' '}
+          © {currentYear} ECOSYZ. All rights reserved. Built with{' '}
           <span className="text-emerald-400">❤️</span> for global innovation.
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- compute the year dynamically in `Footer`

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f7854ce008332ad7240955c28a523