### PR TITLE
Add header and footer to placeholder pages

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,14 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function CommunityPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow p-8">
+        <p>Coming soon</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/openresources/page.tsx
+++ b/app/openresources/page.tsx
@@ -1,0 +1,14 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function OpenResourcesPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow p-8">
+        <p>Coming soon</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,14 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function ProjectsPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow p-8">
+        <p>Coming soon</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/whitepaper/page.tsx
+++ b/app/whitepaper/page.tsx
@@ -1,0 +1,14 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function WhitepaperPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow p-8">
+        <p>Coming soon</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- include `Header` and `Footer` in `/openresources`, `/projects`, `/community`, and `/whitepaper` placeholder pages

## Testing
- `npm install`
- `npm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f784a11cc8332910ba0622a66aa45