### PR TITLE
Add docs under .github directory

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+This folder contains additional guides for working with the OpenIdea project.
+
+- [Setup instructions](setup.md)
+- [Contributing guidelines](contributing.md)
+- [Design decisions](design.md)

--- a/.github/docs/contributing.md
+++ b/.github/docs/contributing.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for considering contributing to OpenIdea!
+
+- Create an issue or comment on an existing one before starting work.
+- Fork the repository and create a feature branch.
+- Run `npm install` and `npm run lint` before committing.
+- Submit a pull request describing your changes.
+
+By contributing you agree to license your work under the MIT License.

--- a/.github/docs/design.md
+++ b/.github/docs/design.md
@@ -1,0 +1,9 @@
+# Design Decisions
+
+OpenIdea is built with [Next.js](https://nextjs.org) and styled using Tailwind CSS. The project aims for a minimal setup so newcomers can easily contribute.
+
+- **Next.js App Router** is used for file-based routing and server components.
+- **Tailwind CSS** provides utility-first styling.
+- **Dark mode** is implemented with `next-themes`.
+
+Further design discussions will be documented here as the project evolves.

--- a/.github/docs/setup.md
+++ b/.github/docs/setup.md
@@ -1,0 +1,12 @@
+# Project Setup
+
+These steps get the project running locally.
+
+1. Install Node.js 18 or later.
+2. Install dependencies with `npm install`.
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+4. Open <http://localhost:3000> in your browser.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ npm run dev
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser.
 
+## Documentation
+
+Additional guides covering setup, contributing, and design choices are
+available in the [docs](.github/docs/README.md) directory.
+
 ## Contributing
 
 Pull requests are welcome. By contributing you agree to the terms of the MIT License.


### PR DESCRIPTION
## Summary
- move documentation into `.github/docs` so it appears in GitHub's docs tab
- update main README link to new location

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities)*
- `npm run build` *(fails: cannot fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686f7f566b288332a4cce57948c4c2b9