### PR TITLE
Add chat bot widget in footer

### DIFF
--- a/app/components/ChallengesSection.tsx
+++ b/app/components/ChallengesSection.tsx
@@ -23,7 +23,7 @@ export default function ChallengesSection() {
                 <span><span className="font-medium text-white">Fragmentation and Scope:</span> Open resources are scattered across domains (software, data, hardware, research, designs, media, etc.)</span>
               </li>
               <li className="flex items-start"><i className="fas fa-dot-circle text-red-400 mt-1 mr-3"></i>
-                <span><span className="font-medium text-white">Technical Complexity:</span> Heterogeneous data: Unifying metadata for code, papers, datasets, designs is hard—there's no single schema</span>
+                  <span><span className="font-medium text-white">Technical Complexity:</span> Heterogeneous data: Unifying metadata for code, papers, datasets, designs is hard—there&apos;s no single schema</span>
               </li>
               <li className="flex items-start"><i className="fas fa-dot-circle text-red-400 mt-1 mr-3"></i>
                 <span><span className="font-medium text-white">Data Licensing & Legal Issues:</span> Licensing and copyright: Even open data and research have varied licenses; combining or redistributing can be legally tricky</span>

--- a/app/components/ChatBot.tsx
+++ b/app/components/ChatBot.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ChatBot() {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const handleSend = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    setMessages([...messages, input.trim()]);
+    setInput('');
+  };
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50 text-sm">
+      {open ? (
+        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg w-72 flex flex-col h-80">
+          <div className="p-2 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+            <span className="font-semibold">Chat</span>
+            <button onClick={() => setOpen(false)} aria-label="Close chat" className="hover:text-red-500">
+              &times;
+            </button>
+          </div>
+          <div className="flex-grow p-2 overflow-y-auto space-y-2">
+            {messages.length === 0 && (
+              <p className="text-gray-500">How can we help?</p>
+            )}
+            {messages.map((msg, idx) => (
+              <div key={idx} className="self-end max-w-full">
+                <div className="bg-emerald-500 text-white p-2 rounded-md break-words">
+                  {msg}
+                </div>
+              </div>
+            ))}
+          </div>
+          <form onSubmit={handleSend} className="p-2 border-t border-gray-200 dark:border-gray-700">
+            <input
+              type="text"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-700 p-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none"
+              value={input}
+              placeholder="Type a message..."
+              onChange={(e) => setInput(e.target.value)}
+            />
+          </form>
+        </div>
+      ) : (
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="Open chat"
+          className="p-3 rounded-full bg-gradient-to-r from-emerald-400 to-cyan-400 text-gray-900 shadow-lg hover:scale-105 transition"
+        >
+          Chat
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/components/CommunitySection.tsx
+++ b/app/components/CommunitySection.tsx
@@ -10,7 +10,7 @@ export default function CommunitySection() {
         <div className="lg:text-center mb-14">
           <h2 className="text-base text-cyan-300 font-semibold tracking-widest uppercase">Community</h2>
           <p className="mt-2 text-3xl sm:text-4xl font-extrabold text-transparent bg-gradient-to-r from-emerald-300 via-cyan-400 to-teal-300 bg-clip-text animate-glow">
-            Who It's For
+            Who It&apos;s For
           </p>
           <p className="mt-4 max-w-2xl mx-auto text-lg text-teal-100/80 font-medium">
             Builders, developers, researchers, students, educators, entrepreneurs, creators.

--- a/app/components/FeedbackForm.tsx
+++ b/app/components/FeedbackForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function FeedbackForm() {
+  const [message, setMessage] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // In a real app, you'd send this to a backend service
+    setSubmitted(true);
+    setMessage('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full max-w-xl mx-auto" aria-label="Send us feedback">
+      <textarea
+        className="w-full p-4 rounded-md border border-gray-300 dark:border-gray-700 bg-transparent resize-none focus:outline-none focus:ring-2 focus:ring-emerald-400"
+        rows={5}
+        value={message}
+        placeholder="Share your thoughts..."
+        onChange={(e) => setMessage(e.target.value)}
+        required
+      />
+      <div className="mt-4 flex justify-end">
+        <button
+          type="submit"
+          className="px-6 py-2 rounded-md bg-gradient-to-r from-emerald-400 to-cyan-400 text-gray-900 font-semibold shadow hover:scale-105 transition"
+        >
+          Submit
+        </button>
+      </div>
+      {submitted && (
+        <p className="mt-4 text-emerald-500">Thank you for your feedback!</p>
+      )}
+    </form>
+  );
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import ChatBot from './ChatBot';
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
@@ -89,6 +90,7 @@ export default function Footer() {
           <span className="text-emerald-400">❤️</span> for global innovation.
         </div>
       </footer>
+      <ChatBot />
     </>
   );
 }

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -23,11 +23,12 @@ export default function Header() {
       </Link>
 
       <nav className="space-x-6 text-sm font-medium flex items-center gap-4">
-       <Link href="/openresources" className="hover:text-green-400 transition">Resources</Link>
+        <Link href="/openresources" className="hover:text-green-400 transition">Resources</Link>
         <Link href="/projects" className="hover:text-green-400 transition">Projects</Link>
         <Link href="/community" className="hover:text-green-400 transition">Community</Link>
         <Link href="/whitepaper" className="hover:text-green-400 transition">Whitepaper</Link>
-         <button
+        <Link href="/feedback" className="hover:text-green-400 transition">Feedback</Link>
+        <button
           onClick={toggleTheme}
           aria-label="Toggle Theme"
           className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -33,14 +33,14 @@ export default function Hero() {
                 </span>
               </h1>
               <p className="text-lg md:text-xl text-teal-100/90 font-medium mt-6">
-                The World's Open Innovation Infrastructure
+                The World&apos;s Open Innovation Infrastructure
               </p>
               <p className="mt-2 text-teal-200/70 text-lg md:text-xl">
                 The Home for Builders, Dreamers, and Doers
               </p>
               <p className="mt-2 text-gray-400 text-base md:text-lg max-w-xl mx-auto lg:mx-0">
 
-                All the world's open knowledge—unified. Build, collaborate, and change the world together, openly.
+                All the world&apos;s open knowledge—unified. Build, collaborate, and change the world together, openly.
               </p>
               <div className="mt-10 flex flex-col sm:flex-row sm:justify-start gap-4 justify-center">
                 <a

--- a/app/components/UniquePoints.tsx
+++ b/app/components/UniquePoints.tsx
@@ -26,7 +26,7 @@ export default function UniquePoints() {
               <i className="fas fa-bolt text-xl"></i>
             </div>
             <h3 className="mt-4 text-lg font-semibold">Discovery → Action</h3>
-            <p className="mt-2 text-base text-teal-100/70">Don't just read—build, remix, and do something immediately</p>
+            <p className="mt-2 text-base text-teal-100/70">Don&apos;t just read—build, remix, and do something immediately</p>
           </div>
           <div className="text-center bg-[#162322] border border-emerald-400/30 rounded-xl p-6 shadow-md">
             <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-purple-700/30 text-purple-200">

--- a/app/feedback/page.tsx
+++ b/app/feedback/page.tsx
@@ -1,0 +1,18 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import FeedbackForm from '../components/FeedbackForm';
+
+export default function FeedbackPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-grow flex items-center justify-center p-6">
+        <div className="w-full max-w-2xl">
+          <h1 className="text-3xl font-bold mb-6 text-center">We value your feedback</h1>
+          <FeedbackForm />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: 'Open Idea',
-  description: "The World's Open Innovation Infrastructure",
+  description: "The World&apos;s Open Innovation Infrastructure",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- add a `ChatBot` component with a small chat window
- include ChatBot at the bottom of the footer so it's available on every page
- escape apostrophes in several components to satisfy lint rules

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7f4ccf4083329b450dea7ef7f986